### PR TITLE
StaticGeneratorException on class-based generic views

### DIFF
--- a/staticgenerator/__init__.py
+++ b/staticgenerator/__init__.py
@@ -153,6 +153,7 @@ class StaticGenerator(object):
         """
 
         request = self.http_request()
+        request.method = 'GET'
         request.path_info = path
         request.META.setdefault('SERVER_PORT', 80)
         request.META.setdefault('SERVER_NAME', self.server_name)


### PR DESCRIPTION
AttributeError is being raised when `quick_publish` is called passing a path processed by a [class-based generic view](https://docs.djangoproject.com/en/1.3/topics/class-based-views/). The error occurs exactily in [this line](https://github.com/django/django/blob/1.3/django/views/generic/base.py#L61), using Django 1.3, in an attempt to lower case `request.method` which is not defined.

The solution was implemented using only [one line of code](https://github.com/adonescunha/staticgenerator/blob/master/staticgenerator/__init__.py#L156) in `staticgenerator.StaticGenerator.get_content_from_path`:

``` python
        request = self.http_request()
        request.method = 'GET' #<====
        request.path_info = path
```

Maybe a more elaborated solution is needed to avoid simliar issues, but this tiny modification solved my problems.
