### PR TITLE
Fix crash when publishing static pages

### DIFF
--- a/staticgenerator/__init__.py
+++ b/staticgenerator/__init__.py
@@ -156,6 +156,7 @@ class StaticGenerator(object):
         request.path_info = path
         request.META.setdefault('SERVER_PORT', 80)
         request.META.setdefault('SERVER_NAME', self.server_name)
+        request.META.setdefault('REMOTE_ADDR', '127.0.0.1')
 
         handler = DummyHandler()
         try:

--- a/staticgenerator/__init__.py
+++ b/staticgenerator/__init__.py
@@ -154,6 +154,8 @@ class StaticGenerator(object):
 
         request = self.http_request()
         request.path_info = path
+        request.GET = {}
+        request.REQUEST = request.GET
         request.META.setdefault('SERVER_PORT', 80)
         request.META.setdefault('SERVER_NAME', self.server_name)
         request.META.setdefault('REMOTE_ADDR', '127.0.0.1')


### PR DESCRIPTION
In order to publish static pages, **staticgenerator** makes a fake request (using its `DummyHandler`) to the generated page. It doesn't provide a `REMOTE_ADDR` or a `request.REQUEST` field. This can cause middleware that is expecting such fields to crash, which makes static page generation fail. These fixes solve that problem.
